### PR TITLE
Test with GHC 7.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ ghc:
   - 7.8
   - 7.6
   - 7.4
-  - 7.2
 
 install:
   - cabal sdist && cabal install --enable-tests dist/terminal-size-*.tar.gz


### PR DESCRIPTION
I had hoped to test with 7.4 and 7.2 on Travis, but seems Travis no longer has 7.2 installed. Might as well test with 7.4 since it works, and it can be useful to go back an extra version if there's nothing stopping you.
