### PR TITLE
Cygwin/MSYS support

### DIFF
--- a/terminal-size.cabal
+++ b/terminal-size.cabal
@@ -32,6 +32,9 @@ library
   if impl(ghc >= 7.4 && < 7.6)
      build-depends:
        ghc-prim
+  if os(windows)
+     build-depends:
+       process
 
   build-tools:
     hsc2hs


### PR DESCRIPTION
Currently, the `size` command yields `Nothing` on a Cygwin or MSYS terminal on Windows, which is kind of unfortunate. As a workaround, I use the `process` library to call `stty size` if `c_GetConsoleScreenBufferInfo` fails. `stty` is a part of `coreutils`, so it _should_ be installed by default on Cygwin and MSYS (it worked when I tried it on my installations, at least.)

An alternative would be calling `tput lines` and `tput cols` processes, but that requires `ncurses`, which isn't installed by default on recent versions of Cygwin (plus, it kind of defeats the point of this library in the first place).