### PR TITLE
Drop #let directive, which is a built-in.

### DIFF
--- a/src/System/Console/Terminal/Posix.hsc
+++ b/src/System/Console/Terminal/Posix.hsc
@@ -20,10 +20,6 @@ import System.Posix.Types (Fd(Fd))
 #include <sys/ioctl.h>
 #include <unistd.h>
 
-
-#let alignment t = "%lu", (unsigned long)offsetof(struct {char x__; t (y__); }, y__)
-
-
 -- Interesting part of @struct winsize@
 data CWin = CWin CUShort CUShort
 

--- a/src/System/Console/Terminal/Posix.hsc
+++ b/src/System/Console/Terminal/Posix.hsc
@@ -20,6 +20,10 @@ import System.Posix.Types (Fd(Fd))
 #include <sys/ioctl.h>
 #include <unistd.h>
 
+#if defined(__GLASGOW_HASKELL__) && (__GLASGOW_HASKELL__ < 800)
+#let alignment t = "%lu", (unsigned long)offsetof(struct {char x__; t (y__); }, y__)
+#endif
+
 -- Interesting part of @struct winsize@
 data CWin = CWin CUShort CUShort
 


### PR DESCRIPTION
`#alignment` is a haskell/hsc2hs builtin. (https://github.com/haskell/hsc2hs#input-syntax)