### PR TITLE
Move stderr of stty to pipe

### DIFF
--- a/src/System/Console/Terminal/Windows.hs
+++ b/src/System/Console/Terminal/Windows.hs
@@ -42,6 +42,7 @@ size = do
                 let stty = (shell "stty size") {
                       std_in  = UseHandle stdin
                     , std_out = CreatePipe
+                    , std_err = CreatePipe
                     }
                 (_, mbStdout, _, rStty) <- createProcess stty
                 exStty <- waitForProcess rStty


### PR DESCRIPTION
In certain scenarios, `stty` can error out; as the `std_err` configuration value of the relevant process is unset, any error messages from `stty` are output to the console. This usually does not occur, but if a program using `terminal-size` is run in e.g. an emacs shell buffer, these errors are output, as `stty` can’t run in this environment. This is not normally a problem, but I would argue it comes under the heading of ‘unexpected behaviour’ and so should probably be fixed. This problem also causes bug https://github.com/commercialhaskell/stack/issues/4901 in `stack`, which stops many people from using the Intero development environment.