### PR TITLE
use CPP offset, without let, for alignment

### DIFF
--- a/src/System/Console/Terminal/Posix.hsc
+++ b/src/System/Console/Terminal/Posix.hsc
@@ -20,16 +20,12 @@ import System.Posix.Types (Fd(Fd))
 #include <sys/ioctl.h>
 #include <unistd.h>
 
-
-#let alignment t = "%lu", (unsigned long)offsetof(struct {char x__; t (y__); }, y__)
-
-
 -- Interesting part of @struct winsize@
 data CWin = CWin CUShort CUShort
 
 instance Storable CWin where
   sizeOf _ = (#size struct winsize)
-  alignment _ = (#alignment struct winsize)
+  alignment _ = (#offset struct winsize, ws_col)
   peek ptr = do
     row <- (#peek struct winsize, ws_row) ptr
     col <- (#peek struct winsize, ws_col) ptr


### PR DESCRIPTION
With this change, it is possible to cross-compile (linux x86_64 to linux aarch64 tested).