### PR TITLE
posix: Fix ioctl foreign import

### DIFF
--- a/src/System/Console/Terminal/Posix.hsc
+++ b/src/System/Console/Terminal/Posix.hsc
@@ -1,3 +1,4 @@
+{-# LANGUAGE CApiFFI #-}
 
 module System.Console.Terminal.Posix
   ( size, fdSize, hSize
@@ -51,8 +52,8 @@ fdSize (Fd fd) = with (CWin 0 0) $ \ws -> do
   handler :: IOError -> IO (Maybe (Window h))
   handler _ = return Nothing
 
-foreign import ccall "sys/ioctl.h ioctl"
-  ioctl :: CInt -> CInt -> Ptr CWin -> IO CInt
+foreign import capi "sys/ioctl.h ioctl"
+  ioctl :: CInt -> CULong -> Ptr CWin -> IO CInt
 
 size :: Integral n => IO (Maybe (Window n))
 size = fdSize (Fd (#const STDOUT_FILENO))


### PR DESCRIPTION
Previously the type of the `request` argument of `ioctl`'s
`foreign import` was incorrect. This can result in incorrect
code generation (and subsequent unsoundness) on some platforms.
Moreover, the import used the `ccall` calling convention, which can
break in surprising ways on platforms which play tricks with CPP.