### PR TITLE
Fix AArch64/Darwin (a.k.a. Apple silicon / M1)

### DIFF
--- a/src/System/Console/Terminal/Posix.hsc
+++ b/src/System/Console/Terminal/Posix.hsc
@@ -1,3 +1,4 @@
+{-# LANGUAGE CApiFFI #-}
 
 module System.Console.Terminal.Posix
   ( size, fdSize, hSize
@@ -51,7 +52,7 @@ fdSize (Fd fd) = with (CWin 0 0) $ \ws -> do
   handler :: IOError -> IO (Maybe (Window h))
   handler _ = return Nothing
 
-foreign import ccall "sys/ioctl.h ioctl"
+foreign import capi "sys/ioctl.h ioctl"
   ioctl :: CInt -> CInt -> Ptr CWin -> IO CInt
 
 size :: Integral n => IO (Maybe (Window n))


### PR DESCRIPTION
Before this change, all of the size utilities return 0 rows and
0 columns on Apple Silicon machines.  This change fixes that by
switching from the `ccall` calling convention to the `capi`
calling convention.

This is essentially the same fix as in
https://github.com/judah/haskeline/pull/163 and this post explains
why the fix works:

https://www.haskell.org/ghc/blog/20210709-capi-usage.html