### PR TITLE
Relax upper bound on Win32

### DIFF
--- a/terminal-size.cabal
+++ b/terminal-size.cabal
@@ -35,7 +35,7 @@ library
   if os(windows)
      build-depends:
        process,
-       Win32 >= 2.13.2.0 && < 2.14
+       Win32 >= 2.13.2.0 && < 2.15
 
   build-tools:
     hsc2hs


### PR DESCRIPTION
Needs hackage revision @Bodigrim

I tested manually on windows.

![terminal_size](https://github.com/user-attachments/assets/964d744d-d908-48f4-b612-ae4dd460462c)
